### PR TITLE
Production environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,11 @@
 # See README.md for details on all of these variables.
-ACCESS_KEY_ID=dummy key
-SECRET_ACCESS_KEY=dummy access key
-BUCKET_NAME=tax-tribs-doc-upload-test
-MOJSSO_ID=dummy id
-MOJSSO_SECRET=dummy secret
-MOJSSO_URL=http://localhost:5000
-MOJSSO_ORG=hmcts.moj
-MOJSSO_ROLE=viewer
-MOJSSO_CALLBACK_URI=http://localhost:3000/oauth/callback
-MOJSSO_TOKEN_REDIRECT_URI=http://localhost:3000/oauth/callback
+export ACCESS_KEY_ID=dummy key
+export SECRET_ACCESS_KEY=dummy access key
+export BUCKET_NAME=tax-tribs-doc-upload-test
+export MOJSSO_ID=dummy id
+export MOJSSO_SECRET=dummy secret
+export MOJSSO_URL=http://localhost:5000
+export MOJSSO_ORG=hmcts.moj
+export MOJSSO_ROLE=viewer
+export MOJSSO_CALLBACK_URI=http://localhost:3000/oauth/callback
+export MOJSSO_TOKEN_REDIRECT_URI=http://localhost:3000/oauth/callback

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ tags
 .env
 .env.test
 .env.development
+.env.production

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,12 @@
-FROM ruby:2.3.1
-RUN mkdir /app
-WORKDIR /app
-ADD Gemfile /app/Gemfile
-ADD Gemfile.lock /app/Gemfile.lock
-RUN bundle install
-ADD . /app
+FROM ministryofjustice/ruby:2.3.1-webapp-onbuild
+
+ENV PUMA_PORT 3000
+ENV RACK_ENV production
+
+RUN touch /etc/inittab
+
+RUN apt-get update && apt-get install -y
+
+EXPOSE $PUMA_PORT
+
+ENTRYPOINT ["./run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ministryofjustice/ruby:2.3.1-webapp-onbuild
 
-ENV PUMA_PORT 3000
+ENV PUMA_PORT 9292
 ENV RACK_ENV production
 
 RUN touch /etc/inittab

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+cd /usr/src/app
+echo "Running app"
+bundle exec puma -p $PUMA_PORT


### PR DESCRIPTION
It's leaking a lot of information on live when an error occurs. Ensuring it is running in production mode will stop this.  

I've also added the exports to make it easier to tweak the environment variables when not using dotenv directly (i.e. in development and 'pseudo' production mode-production mode on a local machine). 