### PR TITLE
Enable logging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 gem 'aws-sdk'
 gem 'erubis'
+gem 'logstash-logger'
 gem 'oauth2'
 gem 'pry'
 gem 'puma'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,9 @@ GEM
     jmespath (1.3.1)
     json (2.0.2)
     jwt (1.5.6)
+    logstash-event (1.2.02)
+    logstash-logger (0.20.0)
+      logstash-event (~> 1.2)
     memoizable (0.4.2)
       thread_safe (~> 0.3, >= 0.3.1)
     method_source (0.8.2)
@@ -162,6 +165,7 @@ DEPENDENCIES
   dotenv
   erubis
   fuubar
+  logstash-logger
   mutant-rspec
   oauth2
   pry

--- a/lib/tax_tribunal/download.rb
+++ b/lib/tax_tribunal/download.rb
@@ -5,8 +5,10 @@ module TaxTribunal
       # authorised? helper method results in intermittent spec failures,
       # even when the email is not set on the session.
       if session[:email]
+        logger.info({ action: 'download', state: 'authorised', user: session[:email], case: case_id })
         @case = Case.new(case_id)
       else
+        logger.info({ action: 'download', state: 'unauthorised', case: case_id })
         session[:return_to] = "/#{case_id}"
       end
 

--- a/lib/tax_tribunal/downloader.rb
+++ b/lib/tax_tribunal/downloader.rb
@@ -1,8 +1,19 @@
+require 'logger'
+require 'logstash-logger'
+
 module TaxTribunal
   class Downloader < Sinatra::Base
-    enable :sessions
+    # This is exceptionally difficult to stub and any issues will get bubbled
+    # up to the application anyway.
+    # :nocov:
+    configure :production, :development do
+      enable :logging
+      use Rack::CommonLogger, LogStashLogger.new(type: :stdout)
+    end
+    # :nocov:
 
     configure do
+      enable :sessions
       set :raise_errors, true
       set :show_exceptions, false
       set :views, "#{settings.root}/../../views"

--- a/spec/lib/downloader_spec.rb
+++ b/spec/lib/downloader_spec.rb
@@ -1,8 +1,4 @@
 require 'spec_helper'
 
 RSpec.describe TaxTribunal::Downloader do
-  it 'uses email stored in the session to determine authorised state' do
-
-
-  end
 end

--- a/spec/lib/login_spec.rb
+++ b/spec/lib/login_spec.rb
@@ -36,6 +36,16 @@ RSpec.describe TaxTribunal::Login do
           to eq('http://localhost:5000/oauth/authorize?client_id=dummy+id&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Foauth%2Fcallback&response_type=code')
       end
     end
+
+    context 'logging' do
+      let(:logger) { double(:logger) }
+
+      it 'logs the request' do
+        expect(logger).to receive(:info).with({ action: 'login', state: 'existing', message: 'viewer@hmcts.gov.uk' })
+        expect_any_instance_of(Sinatra::Helpers).to receive(:logger).and_return(logger)
+        get '/login', {}, 'rack.session' => { email: 'viewer@hmcts.gov.uk' }
+      end
+    end
   end
 
   describe '/logout' do
@@ -49,7 +59,7 @@ RSpec.describe TaxTribunal::Login do
     it 'shows the user a new login link' do
       get '/logout', {}, 'rack.session' => user_session
       expect(last_response.body).
-        to include("<a href='/login'>Login</a>")
+        to include('Please log in from the specific case page.')
     end
 
     it 'clears the user session' do
@@ -121,6 +131,16 @@ RSpec.describe TaxTribunal::Login do
         follow_redirect!
         expect(last_request.url).
           to eq('http://example.org/logout')
+      end
+    end
+
+    context 'logging' do
+      let(:logger) { double(:logger) }
+
+      it 'logs the request' do
+        expect(logger).to receive(:info).with({ action: 'authorise!', message: parsed_oauth_data }.to_json)
+        expect_any_instance_of(Sinatra::Helpers).to receive(:logger).and_return(logger)
+        get 'oauth/callback?code=deadbeef'
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+ENV['RACK_ENV'] = 'test'
 require 'dotenv'
 Dotenv.load
 
@@ -10,6 +11,7 @@ require_relative '../lib/tax_tribunal'
 require 'rspec'
 require 'rack/test'
 require 'vcr'
+require 'pry'
 
 ENV['RACK_ENV'] = 'test'
 

--- a/views/root.erubis
+++ b/views/root.erubis
@@ -2,8 +2,7 @@
 <h2><%= logged_in %></h2>
 <% end %>
 <% unless session[:email] %>
-<h2>You need to login</h2>
-<a href='/login'>Login</a>
+<h1>Please log in from the specific case page.</h1>
 <% else %>
 <a href='/logout'>Logout</a>
 <% end %>


### PR DESCRIPTION
This outputs it in logstash json format to STDOUT to make it easier to
integrate with kibana. I also replaced the generic login link with a
message directing the user to log in via an existing case.  This was
done to prevent users getting locked into a login/logout loop (it logs
them straight out if they have not requested a specific set of
documents).