### PR TITLE
Add dummy env vars to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,16 @@ FROM ministryofjustice/ruby:2.3.1-webapp-onbuild
 ENV PUMA_PORT 9292
 ENV RACK_ENV production
 
+ENV BUCKET_NAME               replace_this_at_build_time
+ENV MOJSSO_CALLBACK_URI       replace_this_at_build_time
+ENV MOJSSO_ID                 replace_this_at_build_time
+ENV MOJSSO_ORG                replace_this_at_build_time
+ENV MOJSSO_ROLE               replace_this_at_build_time
+ENV MOJSSO_SECRET             replace_this_at_build_time
+ENV MOJSSO_TOKEN_REDIRECT_URI replace_this_at_build_time
+ENV MOJSSO_URL                replace_this_at_build_time
+ENV USER_BUCKET_NAME          replace_this_at_build_time
+
 RUN touch /etc/inittab
 
 RUN rm /etc/apt/sources.list.d/nodesource.list


### PR DESCRIPTION
This enables jenkins to build the docker image. Real values to be
supplied at runtime