### PR TITLE
Enable Sentry error reporting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ Downloader app (the path should normally be `/oauth/callback`).
 A callback parameter required by the OAuth2 `get_token` method.  It does
 not have any application here, but is otherwise required.
 
+### SENTRY_DSN
+
+Only needed in production environments to report unhandled exceptions to Sentry. 
+If variable is not set, Sentry reporting will be disabled.
+
 ### NOTE REGARDING AWS CREDENTIALS
 
 Credentials are not required if the downloader is run within AWS.

--- a/config.ru
+++ b/config.ru
@@ -1,3 +1,7 @@
+require 'raven'
 require_relative 'lib/tax_tribunal'
+
+# Will use SENTRY_DSN environment variable if set
+use Raven::Rack
 
 run TaxTribunal::App

--- a/lib/tax_tribunal/downloader.rb
+++ b/lib/tax_tribunal/downloader.rb
@@ -13,8 +13,6 @@ module TaxTribunal
 
     configure do
       enable :sessions
-      set :raise_errors, true
-      set :show_exceptions, false
       set :views, "#{settings.root}/../../views"
       set :public_folder, "#{settings.root}/../../public"
     end


### PR DESCRIPTION
Also, :raise_errors and :show_exceptions Sinatra configuration settings removed as they are not
needed. On development environment exception stacks are shown by default, but not on production.