### PR TITLE
Stop it breaking on dev/prod

### DIFF
--- a/lib/tax_tribunal/sso_client.rb
+++ b/lib/tax_tribunal/sso_client.rb
@@ -8,7 +8,8 @@ module TaxTribunal
     TOKEN_REDIRECT_URI = ENV.fetch('MOJSSO_TOKEN_REDIRECT_URI')
 
     def authorize_url(session)
-      auth_key, return_to = session.values_at(:auth_key, :return_to)
+      auth_key = session[:auth_key]
+      return_to = session[:return_to]
       oauth_client.auth_code.authorize_url(
         redirect_uri: "#{CALLBACK_URI}?auth_key=#{auth_key}&return_to=#{return_to}"
       )

--- a/spec/lib/sso_client_spec.rb
+++ b/spec/lib/sso_client_spec.rb
@@ -50,7 +50,8 @@ RSpec.describe TaxTribunal::SsoClient do
 
     describe '#authorize_url' do
       before do
-        allow(session).to receive(:values_at).with(:auth_key, :return_to).and_return([1234, 'http://test.com'])
+        allow(session).to receive(:[]).with(:auth_key).and_return(1234)
+        allow(session).to receive(:[]).with(:return_to).and_return('http://test.com')
         subject.authorize_url(session)
       end
 


### PR DESCRIPTION
It appears that `Rack::Session::Abstract::SessionHash` does not respond
to `.values_at`.  I've changed the code and the specs to use standard
hash keys (`session[:key]`).