### PR TITLE
RST-2836 - Fixing an issue with blank space links

### DIFF
--- a/lib/tax_tribunal/case.rb
+++ b/lib/tax_tribunal/case.rb
@@ -16,6 +16,7 @@ module TaxTribunal
       map(&:name).
       reject { |o| o.match(DIRECTORY) }.
       map { |o|
+        o = o.gsub(' ','%20')
         File.new(o)
       }
     end


### PR DESCRIPTION
Azure doesn’t like blank space so replacing it with %20