### PR TITLE
Gem update for security patch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'pry'
 gem 'puma'
 gem 'rake'
 gem 'sentry-raven'
-gem 'sinatra', '~> 1.4.8'
+gem 'sinatra', '~> 2.1'
 gem 'sinatra-router', '~> 0.2.4'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,6 +111,8 @@ GEM
     multi_test (0.1.2)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
+    mustermann (1.1.1)
+      ruby2_keywords (~> 0.0.1)
     mutant (0.10.23)
       abstract_type (~> 0.0.7)
       adamantium (~> 0.2.0)
@@ -158,8 +160,8 @@ GEM
     puma (5.2.2)
       nio4r (~> 2.0)
     racc (1.5.2)
-    rack (1.6.13)
-    rack-protection (1.5.5)
+    rack (2.2.3)
+    rack-protection (2.1.0)
       rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -196,6 +198,7 @@ GEM
     rubocop-rspec (1.41.0)
       rubocop (>= 0.68.1)
     ruby-progressbar (1.11.0)
+    ruby2_keywords (0.0.4)
     safe_yaml (1.0.4)
     sentry-raven (2.3.0)
       faraday (>= 0.7.6, < 1.0)
@@ -204,10 +207,11 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    sinatra (1.4.8)
-      rack (~> 1.5)
-      rack-protection (~> 1.4)
-      tilt (>= 1.3, < 3)
+    sinatra (2.1.0)
+      mustermann (~> 1.0)
+      rack (~> 2.2)
+      rack-protection (= 2.1.0)
+      tilt (~> 2.0)
     sinatra-router (0.2.4)
       sinatra (>= 1.4, < 3.0)
     thread_safe (0.3.6)
@@ -268,7 +272,7 @@ DEPENDENCIES
   rubocop-rspec
   sentry-raven
   simplecov
-  sinatra (~> 1.4.8)
+  sinatra (~> 2.1)
   sinatra-router (~> 0.2.4)
   vcr
   webmock

--- a/lib/tax_tribunal/downloader.rb
+++ b/lib/tax_tribunal/downloader.rb
@@ -20,7 +20,7 @@ module TaxTribunal
     # :nocov:
 
     def current_user
-      @current_user ||= User.find(session.fetch(:auth_key))
+      @current_user ||= User.find(session[:auth_key])
     end
 
     def logged_in?

--- a/spec/lib/downloader_spec.rb
+++ b/spec/lib/downloader_spec.rb
@@ -7,13 +7,13 @@ RSpec.describe TaxTribunal::Downloader do
 
   describe '#current_user' do
     it 'uses session[:auth_key] to find the current user' do
-      expect(session).to receive(:fetch).with(:auth_key)
+      expect(session).to receive(:[]).with(:auth_key)
       allow(subject).to receive(:session).and_return(session)
       subject.current_user
     end
 
     it 'calls User#find' do
-      allow(session).to receive(:fetch).with(:auth_key).and_return(12_345)
+      allow(session).to receive(:[]).with(:auth_key).and_return(12_345)
       allow(subject).to receive(:session).and_return(session)
       expect(TaxTribunal::User).to receive(:find).with(12_345)
       subject.current_user


### PR DESCRIPTION
**Description**

CVE-2020-8161
moderate severity
Vulnerable versions: < 2.1.3
Patched version: 2.1.3

A directory traversal vulnerability exists in rack < 2.2.0 that allows an attacker perform directory traversal vulnerability in the Rack::Directory app that is bundled with Rack which could result in information disclosure.
CVE-2020-8184
high severity
Vulnerable versions: < 2.1.4
Patched version: 2.1.4

A reliance on cookies without validation/integrity check security vulnerability exists in rack < 2.2.3, rack < 2.1.4 that makes it is possible for an attacker to forge a secure or host-only cookie prefix.